### PR TITLE
Replace device_kernel_headers with generated_kernel_headers

### DIFF
--- a/cc/cc.go
+++ b/cc/cc.go
@@ -2204,6 +2204,20 @@ func RewriteLibs(c LinkableInterface, snapshotInfo **SnapshotInfo, actx android.
 	return nonvariantLibs, variantLibs
 }
 
+func RewriteHeaderLibs(c LinkableInterface, snapshotInfo **SnapshotInfo, actx android.BottomUpMutatorContext, config android.Config, list []string) (newHeaderLibs []string) {
+	newHeaderLibs = []string{}
+	for _, entry := range list {
+		// Replace device_kernel_headers with generated_kernel_headers
+		// for inline kernel building
+		if entry == "device_kernel_headers" || entry == "qti_kernel_headers" {
+			newHeaderLibs = append(newHeaderLibs, "generated_kernel_headers")
+			continue
+		}
+		newHeaderLibs = append(newHeaderLibs, entry)
+	}
+	return newHeaderLibs
+}
+
 func (c *Module) DepsMutator(actx android.BottomUpMutatorContext) {
 	if !c.Enabled() {
 		return
@@ -2226,6 +2240,7 @@ func (c *Module) DepsMutator(actx android.BottomUpMutatorContext) {
 	variantNdkLibs := []string{}
 	variantLateNdkLibs := []string{}
 	if ctx.Os() == android.Android {
+		deps.HeaderLibs = RewriteHeaderLibs(c, &snapshotInfo, actx, ctx.Config(), deps.HeaderLibs)
 		deps.SharedLibs, variantNdkLibs = RewriteLibs(c, &snapshotInfo, actx, ctx.Config(), deps.SharedLibs)
 		deps.LateSharedLibs, variantLateNdkLibs = RewriteLibs(c, &snapshotInfo, actx, ctx.Config(), deps.LateSharedLibs)
 		deps.ReexportSharedLibHeaders, _ = RewriteLibs(c, &snapshotInfo, actx, ctx.Config(), deps.ReexportSharedLibHeaders)


### PR DESCRIPTION
* For inline kernel building
* Avoids having to make edits to multiple repos, even if it's a quick replacement

Author: Nolen Johnson <johnsonnolen@gmail.com>

Replace qti_kernel_headers with generated_kernel_headers

* Further avoids edits in CAF repos.

Co-authored-by: Nolen Johnson <johnsonnolen@gmail.com>
Signed-off-by: Hưng Phan <phandinhhungvp2001@gmail.com>
Signed-off-by: Anand Bhat <anandbhat07@gmail.com>